### PR TITLE
Set piece_size when editing an existing torrent

### DIFF
--- a/utils/torrent_utils.py
+++ b/utils/torrent_utils.py
@@ -120,7 +120,8 @@ def create_torrent(directory, temp_dir, edit, hasher):
             reused_torrent.trackers = [announceurl]
             reused_torrent.comment = ecomment
             reused_torrent.created_by = creator
-
+            piece_size = reused_torrent.piece_size
+            
             info_dict = reused_torrent.metainfo['info']
             valid_keys = ['name', 'piece length', 'pieces', 'private', 'source']
 


### PR DESCRIPTION
When editing an existing torrent file, the script would just exit after creating the torrent file, and the error is only written to `main.log`:

```
Error creating torrent: cannot access local variable 'piece_size' where it is not associated with a value
```

This PR fixes this by assigning `piece_size` to the piece size of the existing torrent.